### PR TITLE
Dynamically set the resolution in VNC session

### DIFF
--- a/assets/all/startVNCServerStep2.sh
+++ b/assets/all/startVNCServerStep2.sh
@@ -26,6 +26,15 @@ EOF
 
 fi
 
+if [[ -z "${DIMENSIONS}" ]]; then
+	DIMENSIONS="1024x768"
+fi
+
+if [ ! -f /home/$INITIAL_USERNAME/.vncrc ]; then
+	vncrc_line="\$geometry = \"${DIMENSIONS}\";"
+	echo $vncrc_line > /home/$INITIAL_USERNAME/.vncrc
+fi
+
 rm /tmp/.X51-lock
 rm /tmp/.X11-unix/X51
 tightvncserver -kill :51


### PR DESCRIPTION
This will change the VNC resolution depending on the screen resolution of the device.

Creates a `geometry` variable in the `.vncrc` file to hold the width and height values in the /home/user directory